### PR TITLE
Fixed URLs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -287,9 +287,9 @@ setuptools.setup(
     },
 
     project_urls={
-        'Bug Reports': 'https://github.com/jetperch/pyjoulescope_driver/issues',
+        'Bug Reports': 'https://github.com/jetperch/joulescope_driver/issues',
         'Funding': 'https://www.joulescope.com',
         'Twitter': 'https://twitter.com/joulescope',
-        'Source': 'https://github.com/jetperch/pyjoulescope_driver/',
+        'Source': 'https://github.com/jetperch/joulescope_driver/',
     },
 )


### PR DESCRIPTION
It seems like the project has been renamed some time in the past and these URLs were forgotten to be updated.